### PR TITLE
use open java instead of oracle

### DIFF
--- a/configuration-management/ansible/cloudera_repository.yml
+++ b/configuration-management/ansible/cloudera_repository.yml
@@ -37,7 +37,9 @@
         gpgcheck: yes
         file: "CentOS-Base"
 
-    - name: Install Oracle J2 SDK
+    - name: Install Open JDK
       yum:
-        name: "oracle-j2sdk1.7"
+        name: "java-1.7.0-openjdk"
         state: present
+
+

--- a/configuration-management/ansible/environment/dev.sh
+++ b/configuration-management/ansible/environment/dev.sh
@@ -1,4 +1,4 @@
-export JAVA_HOME=/usr/java/jdk1.7.0_67-cloudera/
+export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
 export HADOOP_CONF_DIR=/etc/hadoop/conf
 export SPARK_HOME=/root/spark/spark-2.0.1-bin-hadoop2.7
 


### PR DESCRIPTION
 It seems like Oracle Java rpms are removed from Cloudera repository. For experimenting purposes we can use Open Java here.